### PR TITLE
Remove some package level variables

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,10 +37,9 @@ type Client struct {
 	StreamingURL string
 }
 
-var (
-	AuthURL = "https://owner-api.teslamotors.com/oauth/token"
-	BaseURL = "https://owner-api.teslamotors.com/api/1"
-)
+var AuthURL = "https://owner-api.teslamotors.com/oauth/token"
+
+const BaseURL = "https://owner-api.teslamotors.com/api/1"
 
 // Generates a new client for the Tesla API
 func NewClient(auth *Auth) (*Client, error) {

--- a/client.go
+++ b/client.go
@@ -16,8 +16,6 @@ type Auth struct {
 	ClientSecret string `json:"client_secret"`
 	Email        string `json:"email"`
 	Password     string `json:"password"`
-	URL          string
-	StreamingURL string
 }
 
 // The token and related elements returned after a successful auth
@@ -32,9 +30,11 @@ type Token struct {
 // Provides the client and associated elements for interacting with the
 // Tesla API
 type Client struct {
-	Auth  *Auth
-	Token *Token
-	HTTP  *http.Client
+	Auth         *Auth
+	Token        *Token
+	HTTP         *http.Client
+	URL          string
+	StreamingURL string
 }
 
 var (
@@ -45,16 +45,11 @@ var (
 
 // Generates a new client for the Tesla API
 func NewClient(auth *Auth) (*Client, error) {
-	if auth.URL == "" {
-		auth.URL = BaseURL
-	}
-	if auth.StreamingURL == "" {
-		auth.StreamingURL = StreamingURL
-	}
-
 	client := &Client{
-		Auth: auth,
-		HTTP: &http.Client{},
+		Auth:         auth,
+		HTTP:         &http.Client{},
+		URL:          BaseURL,
+		StreamingURL: StreamingURL,
 	}
 	token, err := client.authorize(auth)
 	if err != nil {
@@ -67,17 +62,12 @@ func NewClient(auth *Auth) (*Client, error) {
 
 // NewClientWithToken Generates a new client for the Tesla API using an existing token
 func NewClientWithToken(auth *Auth, token *Token) (*Client, error) {
-	if auth.URL == "" {
-		auth.URL = BaseURL
-	}
-	if auth.StreamingURL == "" {
-		auth.StreamingURL = StreamingURL
-	}
-
 	client := &Client{
-		Auth:  auth,
-		HTTP:  &http.Client{},
-		Token: token,
+		Auth:         auth,
+		HTTP:         &http.Client{},
+		Token:        token,
+		URL:          BaseURL,
+		StreamingURL: StreamingURL,
 	}
 	if client.TokenExpired() {
 		return nil, errors.New("supplied token is expired")

--- a/client.go
+++ b/client.go
@@ -33,14 +33,13 @@ type Client struct {
 	Auth         *Auth
 	Token        *Token
 	HTTP         *http.Client
-	URL          string
+	BaseURL      string
 	StreamingURL string
 }
 
 var (
-	AuthURL      = "https://owner-api.teslamotors.com/oauth/token"
-	BaseURL      = "https://owner-api.teslamotors.com/api/1"
-	ActiveClient *Client
+	AuthURL = "https://owner-api.teslamotors.com/oauth/token"
+	BaseURL = "https://owner-api.teslamotors.com/api/1"
 )
 
 // Generates a new client for the Tesla API
@@ -48,7 +47,7 @@ func NewClient(auth *Auth) (*Client, error) {
 	client := &Client{
 		Auth:         auth,
 		HTTP:         &http.Client{},
-		URL:          BaseURL,
+		BaseURL:      BaseURL,
 		StreamingURL: StreamingURL,
 	}
 	token, err := client.authorize(auth)
@@ -56,7 +55,6 @@ func NewClient(auth *Auth) (*Client, error) {
 		return nil, err
 	}
 	client.Token = token
-	ActiveClient = client
 	return client, nil
 }
 
@@ -66,13 +64,12 @@ func NewClientWithToken(auth *Auth, token *Token) (*Client, error) {
 		Auth:         auth,
 		HTTP:         &http.Client{},
 		Token:        token,
-		URL:          BaseURL,
+		BaseURL:      BaseURL,
 		StreamingURL: StreamingURL,
 	}
 	if client.TokenExpired() {
 		return nil, errors.New("supplied token is expired")
 	}
-	ActiveClient = client
 	return client, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -122,8 +122,6 @@ func serveHTTP(t *testing.T) *httptest.Server {
 				So(auth.ClientSecret, ShouldEqual, "def456")
 				So(auth.Email, ShouldEqual, "elon@tesla.com")
 				So(auth.Password, ShouldEqual, "go")
-				So(auth.URL, ShouldEqual, BaseURL)
-				So(auth.StreamingURL, ShouldEqual, StreamingURL)
 			})
 			w.WriteHeader(200)
 			w.Write([]byte("{\"access_token\": \"ghi789\"}"))

--- a/client_test.go
+++ b/client_test.go
@@ -15,9 +15,7 @@ func TestClientSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -27,6 +25,7 @@ func TestClientSpec(t *testing.T) {
 		Password:     "go",
 	}
 	client, err := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should set the HTTP headers", t, func() {
 		req, _ := http.NewRequest("GET", "http://foo.com", nil)
@@ -41,7 +40,6 @@ func TestClientSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }
 
 func TestTokenExpiredSpec(t *testing.T) {
@@ -78,9 +76,7 @@ func TestClientWithTokenSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -98,6 +94,7 @@ func TestClientWithTokenSpec(t *testing.T) {
 	}
 
 	client, err := NewClientWithToken(auth, validToken)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should login with a valid access token", t, func() {
 		So(err, ShouldBeNil)
@@ -105,7 +102,6 @@ func TestClientWithTokenSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }
 
 func serveHTTP(t *testing.T) *httptest.Server {

--- a/client_test.go
+++ b/client_test.go
@@ -125,6 +125,10 @@ func serveHTTP(t *testing.T) *httptest.Server {
 			checkHeaders(t, req)
 			w.WriteHeader(200)
 			w.Write([]byte(VehiclesJSON))
+		case "/api/1/vehicles/1234":
+			checkHeaders(t, req)
+			w.WriteHeader(200)
+			w.Write([]byte(VehicleJSON))
 		case "/api/1/vehicles/1234/mobile_enabled":
 			checkHeaders(t, req)
 			w.WriteHeader(200)

--- a/commands.go
+++ b/commands.go
@@ -44,7 +44,7 @@ func (v Vehicle) AutoparkReverse() error {
 
 // Performs the actual auto park/summon request for the vehicle
 func (v Vehicle) autoPark(action string) error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/autopark_request"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/autopark_request"
 	driveState, _ := v.DriveState()
 	autoParkRequest := &AutoParkRequest{
 		VehicleID: v.VehicleID,
@@ -54,19 +54,19 @@ func (v Vehicle) autoPark(action string) error {
 	}
 	body, _ := json.Marshal(autoParkRequest)
 
-	_, err := sendCommand(apiUrl, body)
+	_, err := v.sendCommand(apiUrl, body)
 	return err
 }
 
 // Enables Sentry Mode
 func (v *Vehicle) EnableSentry() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_sentry_mode"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_sentry_mode"
 	sentryRequest := &SentryData{
 		Mode: "true",
 	}
 
 	body, _ := json.Marshal(sentryRequest)
-	_, err := sendCommand(apiUrl, body)
+	_, err := v.sendCommand(apiUrl, body)
 	return err
 }
 
@@ -79,9 +79,9 @@ func (v *Vehicle) EnableSentry() error {
 // 	} else {
 // 		command += "off"
 // 	}
-// 	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/" + command
+// 	apiUrl := v.c.URL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/" + command
 // 	fmt.Println(apiUrl)
-// 	_, err := sendCommand(apiUrl, nil)
+// 	_, err := v.sendCommand(apiUrl, nil)
 // 	return err
 // }
 
@@ -89,7 +89,7 @@ func (v *Vehicle) EnableSentry() error {
 // keep in mind this is a toggle and the garage door state is unknown
 // a major limitation of Homelink
 func (v Vehicle) TriggerHomelink() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/trigger_homelink"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/trigger_homelink"
 	driveState, _ := v.DriveState()
 	autoParkRequest := &AutoParkRequest{
 		Lat: driveState.Latitude,
@@ -97,14 +97,14 @@ func (v Vehicle) TriggerHomelink() error {
 	}
 	body, _ := json.Marshal(autoParkRequest)
 
-	_, err := sendCommand(apiUrl, body)
+	_, err := v.sendCommand(apiUrl, body)
 	return err
 }
 
 // Wakes up the vehicle when it is powered off
 func (v Vehicle) Wakeup() (*Vehicle, error) {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/wake_up"
-	body, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/wake_up"
+	body, err := v.sendCommand(apiUrl, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -117,80 +117,80 @@ func (v Vehicle) Wakeup() (*Vehicle, error) {
 
 // Opens the charge port so you may insert your charging cable
 func (v Vehicle) OpenChargePort() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_port_door_open"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_port_door_open"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Resets the PIN set for valet mode, if set
 func (v Vehicle) ResetValetPIN() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/reset_valet_pin"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/reset_valet_pin"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Sets the charge limit to the standard setting
 func (v Vehicle) SetChargeLimitStandard() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_standard"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_standard"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Sets the charge limit to the max limit
 func (v Vehicle) SetChargeLimitMax() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_max_range"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_max_range"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Set the charge limit to a custom percentage
 func (v Vehicle) SetChargeLimit(percent int) error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_charge_limit"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_charge_limit"
 	theJson := `{"percent": ` + strconv.Itoa(percent) + `}`
-	_, err := ActiveClient.post(apiUrl, []byte(theJson))
+	_, err := v.c.post(apiUrl, []byte(theJson))
 	return err
 }
 
 // StartCharging starts the charging of the vehicle after you have inserted the
 // charging cable
 func (v Vehicle) StartCharging() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_start"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_start"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Stop the charging of the vehicle
 func (v Vehicle) StopCharging() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_stop"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/charge_stop"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Flashes the lights of the vehicle
 func (v Vehicle) FlashLights() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/flash_lights"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/flash_lights"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Honks the horn of the vehicle
 func (v *Vehicle) HonkHorn() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/honk_horn"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/honk_horn"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Unlock the car's doors
 func (v Vehicle) UnlockDoors() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/door_unlock"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/door_unlock"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Locks the doors of the vehicle
 func (v Vehicle) LockDoors() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/door_lock"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/door_lock"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
@@ -199,54 +199,54 @@ func (v Vehicle) LockDoors() error {
 func (v Vehicle) SetTemprature(driver float64, passenger float64) error {
 	driveTemp := strconv.FormatFloat(driver, 'f', -1, 32)
 	passengerTemp := strconv.FormatFloat(passenger, 'f', -1, 32)
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_temps"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/set_temps"
 	theJson := `{"driver_temp": "` + driveTemp + `", "passenger_temp":` + passengerTemp + `}`
-	_, err := ActiveClient.post(apiUrl, []byte(theJson))
+	_, err := v.c.post(apiUrl, []byte(theJson))
 	return err
 }
 
 // StartAirConditioning starts the air conditioning in the car
 func (v Vehicle) StartAirConditioning() error {
-	url := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/auto_conditioning_start"
-	_, err := sendCommand(url, nil)
+	url := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/auto_conditioning_start"
+	_, err := v.sendCommand(url, nil)
 	return err
 }
 
 // Stops the air conditioning in the car
 func (v Vehicle) StopAirConditioning() error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/auto_conditioning_stop"
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/auto_conditioning_stop"
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // The desired state of the panoramic roof. The approximate percent open
 // values for each state are open = 100%, close = 0%, comfort = 80%, vent = %15, move = set %
 func (v Vehicle) MovePanoRoof(state string, percent int) error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/sun_roof_control"
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/sun_roof_control"
 	theJson := `{"state": "` + state + `", "percent":` + strconv.Itoa(percent) + `}`
-	_, err := ActiveClient.post(apiUrl, []byte(theJson))
+	_, err := v.c.post(apiUrl, []byte(theJson))
 	return err
 }
 
 // Start starts the car by turning it on, requires the password to be sent
 // again
 func (v Vehicle) Start(password string) error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/remote_start_drive?password=" + password
-	_, err := sendCommand(apiUrl, nil)
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/remote_start_drive?password=" + password
+	_, err := v.sendCommand(apiUrl, nil)
 	return err
 }
 
 // Opens the trunk, where values may be 'front' or 'rear'
 func (v Vehicle) OpenTrunk(trunk string) error {
-	apiUrl := BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/trunk_open" // ?which_trunk=" + trunk
+	apiUrl := v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/command/trunk_open" // ?which_trunk=" + trunk
 	theJson := `{"which_trunk": "` + trunk + `"}`
-	_, err := ActiveClient.post(apiUrl, []byte(theJson))
+	_, err := v.c.post(apiUrl, []byte(theJson))
 	return err
 }
 
 // Sends a command to the vehicle
-func sendCommand(url string, reqBody []byte) ([]byte, error) {
-	body, err := ActiveClient.post(url, reqBody)
+func (v *Vehicle) sendCommand(url string, reqBody []byte) ([]byte, error) {
+	body, err := v.c.post(url, reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/commands_test.go
+++ b/commands_test.go
@@ -17,9 +17,7 @@ func TestCommandsSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -29,6 +27,7 @@ func TestCommandsSpec(t *testing.T) {
 		Password:     "go",
 	}
 	client, _ := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should auto park abort Autopark", t, func() {
 		vehicles, err := client.Vehicles()
@@ -221,5 +220,4 @@ func TestCommandsSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }

--- a/states.go
+++ b/states.go
@@ -207,7 +207,7 @@ type MobileEnabledResponse struct {
 // MobileEnabled returns if the vehicle is mobile enabled for Tesla API control
 func (v *Vehicle) MobileEnabled() (bool, error) {
 	r := &MobileEnabledResponse{}
-	if err := ActiveClient.getJSON(v.c.BaseURL+"/vehicles/"+strconv.FormatInt(v.ID, 10)+"/mobile_enabled", r); err != nil {
+	if err := v.c.getJSON(v.c.BaseURL+"/vehicles/"+strconv.FormatInt(v.ID, 10)+"/mobile_enabled", r); err != nil {
 		return false, err
 	}
 	return r.Bool, nil

--- a/states.go
+++ b/states.go
@@ -207,7 +207,7 @@ type MobileEnabledResponse struct {
 
 // MobileEnabled returns if the vehicle is mobile enabled for Tesla API control
 func (v *Vehicle) MobileEnabled() (bool, error) {
-	body, err := ActiveClient.get(BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/mobile_enabled")
+	body, err := v.c.get(v.c.BaseURL + "/vehicles/" + strconv.FormatInt(v.ID, 10) + "/mobile_enabled")
 	if err != nil {
 		return false, err
 	}
@@ -220,7 +220,7 @@ func (v *Vehicle) MobileEnabled() (bool, error) {
 
 // ChargeState returns the charge state of the vehicle
 func (v *Vehicle) ChargeState() (*ChargeState, error) {
-	stateRequest, err := fetchState("/charge_state", v.ID)
+	stateRequest, err := v.c.fetchState("/charge_state", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (v *Vehicle) ChargeState() (*ChargeState, error) {
 
 // ClimateState returns the climate state of the vehicle
 func (v Vehicle) ClimateState() (*ClimateState, error) {
-	stateRequest, err := fetchState("/climate_state", v.ID)
+	stateRequest, err := v.c.fetchState("/climate_state", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (v Vehicle) ClimateState() (*ClimateState, error) {
 }
 
 func (v Vehicle) DriveState() (*DriveState, error) {
-	stateRequest, err := fetchState("/drive_state", v.ID)
+	stateRequest, err := v.c.fetchState("/drive_state", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (v Vehicle) DriveState() (*DriveState, error) {
 
 // GuiSettings returns the GUI settings of the vehicle
 func (v Vehicle) GuiSettings() (*GuiSettings, error) {
-	stateRequest, err := fetchState("/gui_settings", v.ID)
+	stateRequest, err := v.c.fetchState("/gui_settings", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (v Vehicle) GuiSettings() (*GuiSettings, error) {
 }
 
 func (v Vehicle) VehicleState() (*VehicleState, error) {
-	stateRequest, err := fetchState("/vehicle_state", v.ID)
+	stateRequest, err := v.c.fetchState("/vehicle_state", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (v Vehicle) VehicleState() (*VehicleState, error) {
 }
 
 func (v Vehicle) ServiceData() (*ServiceData, error) {
-	stateRequest, err := fetchState("/service_data", v.ID)
+	stateRequest, err := v.c.fetchState("/service_data", v.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -281,9 +281,9 @@ func stateError(sr *StateRequest) error {
 }
 
 // A utility function to fetch the appropriate state of the vehicle
-func fetchState(resource string, id int64) (*StateRequest, error) {
+func (c *Client) fetchState(resource string, id int64) (*StateRequest, error) {
 	stateRequest := &StateRequest{}
-	body, err := ActiveClient.get(BaseURL + "/vehicles/" + strconv.FormatInt(id, 10) + "/data_request" + resource)
+	body, err := c.get(c.BaseURL + "/vehicles/" + strconv.FormatInt(id, 10) + "/data_request" + resource)
 	if err != nil {
 		return nil, err
 	}
@@ -301,8 +301,8 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	log.Println("Retreiving vehicle data")
 	stateRequest := &StateRequest{}
 
-	/*log.Println(BaseURL + "/vehicles/" + strconv.FormatInt(vid, 10) + "/vehicle_data")
-	body, err := ActiveClient.get(BaseURL + "/vehicles/" + strconv.FormatInt(vid, 10) + "/vehicle_data")
+	/*log.Println(v.c.URL + "/vehicles/" + strconv.FormatInt(vid, 10) + "/vehicle_data")
+	body, err := v.c.get(v.c.URL + "/vehicles/" + strconv.FormatInt(vid, 10) + "/vehicle_data")
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	}*/
 
 	// climate_state
-	stateRequestClimate, err := fetchState("/climate_state", v.ID)
+	stateRequestClimate, err := v.c.fetchState("/climate_state", v.ID)
 	if err != nil {
 		log.Println("Error getting climate_state")
 		return nil, err
@@ -319,7 +319,7 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	stateRequest.Response.ClimateState = stateRequestClimate.Response.ClimateState
 
 	// drive_state
-	stateRequestGui, err := fetchState("/drive_state", v.ID)
+	stateRequestGui, err := v.c.fetchState("/drive_state", v.ID)
 	if err != nil {
 		log.Println("Error getting drive_state")
 		return nil, err
@@ -327,7 +327,7 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	stateRequest.Response.DriveState = stateRequestGui.Response.DriveState
 
 	// gui_settings
-	stateRequestSettings, err := fetchState("/gui_settings", v.ID)
+	stateRequestSettings, err := v.c.fetchState("/gui_settings", v.ID)
 	if err != nil {
 		log.Println("Error getting gui_settings")
 		return nil, err
@@ -335,7 +335,7 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	stateRequest.Response.GuiSettings = stateRequestSettings.Response.GuiSettings
 
 	// vehicle_state
-	stateRequestVehicle, err := fetchState("/vehicle_state", v.ID)
+	stateRequestVehicle, err := v.c.fetchState("/vehicle_state", v.ID)
 	if err != nil {
 		log.Println("Error getting vehicle_state")
 		return nil, err
@@ -343,7 +343,7 @@ func (v Vehicle) Data(vid int64) (*StateRequest, error) {
 	stateRequest.Response.VehicleState = stateRequestVehicle.Response.VehicleState
 
 	// charge_state
-	stateRequestCharge, err := fetchState("/charge_state", v.ID)
+	stateRequestCharge, err := v.c.fetchState("/charge_state", v.ID)
 	if err != nil {
 		log.Println("Error getting charge_state")
 		return nil, err

--- a/states_test.go
+++ b/states_test.go
@@ -22,9 +22,7 @@ func TestStatesSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -34,6 +32,7 @@ func TestStatesSpec(t *testing.T) {
 		Password:     "go",
 	}
 	client, _ := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should get mobile enabled status", t, func() {
 		vehicles, _ := client.Vehicles()
@@ -117,5 +116,4 @@ func TestStatesSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }

--- a/stream.go
+++ b/stream.go
@@ -33,10 +33,10 @@ type StreamEvent struct {
 
 // Requests a stream from the vehicle and returns a Go channel
 func (v Vehicle) Stream() (chan *StreamEvent, chan error, error) {
-	url := StreamingURL + "/stream/" + strconv.FormatUint(v.VehicleID, 10) + "/?values=" + StreamParams
+	url := v.c.StreamingURL + "/stream/" + strconv.FormatUint(v.VehicleID, 10) + "/?values=" + StreamParams
 	req, _ := http.NewRequest("GET", url, nil)
-	req.SetBasicAuth(ActiveClient.Auth.Email, v.Tokens[0])
-	resp, err := ActiveClient.HTTP.Do(req)
+	req.SetBasicAuth(v.c.Auth.Email, v.Tokens[0])
+	resp, err := v.c.HTTP.Do(req)
 
 	if err != nil {
 		return nil, nil, err

--- a/stream_test.go
+++ b/stream_test.go
@@ -15,15 +15,24 @@ func TestStreamSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
-	vehicle := &Vehicle{}
-	vehicle.VehicleID = 123
-	vehicle.Tokens = []string{"456", "789"}
 
-	previousStreamingURL := StreamingURL
-	StreamingURL = ts.URL
+	auth := &Auth{
+		GrantType:    "password",
+		ClientID:     "abc123",
+		ClientSecret: "def456",
+		Email:        "elon@tesla.com",
+		Password:     "go",
+	}
+	client, _ := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
+	client.StreamingURL = ts.URL
+
+	vehicle := &Vehicle{
+		c:         client,
+		VehicleID: 123,
+		Tokens:    []string{"456", "789"},
+	}
 
 	Convey("Should get stream events", t, func() {
 		eventChan, errChan, err := vehicle.Stream()
@@ -58,6 +67,4 @@ func TestStreamSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
-	StreamingURL = previousStreamingURL
 }

--- a/vehicles.go
+++ b/vehicles.go
@@ -88,5 +88,6 @@ func (c *Client) Vehicle(vehicleId int64) (*Vehicle, error) {
 	if err := c.getJSON(c.BaseURL+"/vehicles/"+strconv.FormatInt(vehicleId, 10), resp); err != nil {
 		return nil, err
 	}
+	resp.Response.c = c
 	return resp.Response, nil
 }

--- a/vehicles.go
+++ b/vehicles.go
@@ -85,7 +85,7 @@ func (c *Client) Vehicles() ([]*Vehicle, error) {
 // Fetches the vehicle by ID associated to a Tesla account via the API
 func (c *Client) Vehicle(vehicleId int64) (*Vehicle, error) {
 	resp := &VehicleResponse{}
-	if err := c.getJSON(BaseURL+"/vehicles/"+strconv.FormatInt(vehicleId, 10), resp); err != nil {
+	if err := c.getJSON(c.BaseURL+"/vehicles/"+strconv.FormatInt(vehicleId, 10), resp); err != nil {
 		return nil, err
 	}
 	return resp.Response, nil

--- a/vehicles.go
+++ b/vehicles.go
@@ -2,6 +2,7 @@ package tesla
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 )
 
@@ -84,4 +85,17 @@ func (c *Client) Vehicles() ([]*Vehicle, error) {
 		v.c = c
 	}
 	return vehiclesResponse.Response, nil
+}
+
+// Fetches the vehicle by ID associated to a Tesla account via the API
+func (c *Client) Vehicle(vehicleId int64) (*Vehicle, error) {
+	resp := &VehicleResponse{}
+	body, err := c.get(BaseURL + "/vehicles/" + strconv.FormatInt(vehicleId, 10))
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, resp); err != nil {
+		return nil, err
+	}
+	return resp.Response, nil
 }

--- a/vehicles.go
+++ b/vehicles.go
@@ -26,6 +26,8 @@ type Vehicle struct {
 	APIVersion             int            `json:"api_version"`
 	CommandSigning         string         `json:"command_signing"`
 	VehicleConfig          *VehicleConfig `json:"vehicle_config"`
+
+	c *Client
 }
 
 type VehicleConfig struct {
@@ -71,12 +73,15 @@ type VehiclesResponse struct {
 // Fetches the vehicles associated to a Tesla account via the API
 func (c *Client) Vehicles() ([]*Vehicle, error) {
 	vehiclesResponse := &VehiclesResponse{}
-	body, err := c.get(BaseURL + "/vehicles")
+	body, err := c.get(c.BaseURL + "/vehicles")
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal(body, vehiclesResponse); err != nil {
 		return nil, err
+	}
+	for _, v := range vehiclesResponse.Response {
+		v.c = c
 	}
 	return vehiclesResponse.Response, nil
 }

--- a/vehicles_test.go
+++ b/vehicles_test.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	VehiclesJSON = `{"response":[{"color":null,"display_name":"Macak","id":1234,"option_codes":"MS04,RENA,AU01,BC0R,BP01,BR01,BS00,CDM0,CH00,PBSB,CW02,DA02,DCF0,DRLH,DSH7,DV4W,FG02,HP00,IDPB,IX01,LP01,ME02,MI00,PA00,PF01,PI01,PK00,PS01,PX00,PX4D,QNEB,RFP2,SC01,SP00,SR01,SU01,TM00,TP03,TR01,UTAB,WTSG,WTX0,X001,X003,X007,X011,X013,X019,X024,X027,X028,X031,X037,X040,YF01,COUS","vehicle_id":456,"vin":"abc123","tokens":["1","2"],"state":"online","id_s":"789","remote_start_enabled":true,"calendar_enabled":true,"notifications_enabled":true,"backseat_token":null,"backseat_token_updated_at":null}],"count":1}`
+	VehicleJSON  = `{"response":{"color":null,"display_name":"Macak","id":1234,"option_codes":"MS04,RENA,AU01,BC0R,BP01,BR01,BS00,CDM0,CH00,PBSB,CW02,DA02,DCF0,DRLH,DSH7,DV4W,FG02,HP00,IDPB,IX01,LP01,ME02,MI00,PA00,PF01,PI01,PK00,PS01,PX00,PX4D,QNEB,RFP2,SC01,SP00,SR01,SU01,TM00,TP03,TR01,UTAB,WTSG,WTX0,X001,X003,X007,X011,X013,X019,X024,X027,X028,X031,X037,X040,YF01,COUS","vehicle_id":456,"vin":"abc123","tokens":["1","2"],"state":"online","id_s":"789","remote_start_enabled":true,"calendar_enabled":true,"notifications_enabled":true,"backseat_token":null,"backseat_token_updated_at":null},"count":1}`
 )
 
 func TestVehiclesSpec(t *testing.T) {
@@ -34,4 +35,32 @@ func TestVehiclesSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
+}
+
+func TestVehicle(t *testing.T) {
+	ts := serveHTTP(t)
+	defer ts.Close()
+	previousAuthURL := AuthURL
+	previousURL := BaseURL
+	AuthURL = ts.URL + "/oauth/token"
+	BaseURL = ts.URL + "/api/1"
+
+	auth := &Auth{
+		GrantType:    "password",
+		ClientID:     "abc123",
+		ClientSecret: "def456",
+		Email:        "elon@tesla.com",
+		Password:     "go",
+	}
+	client, _ := NewClient(auth)
+
+	Convey("Should get vehicle", t, func() {
+		vehicle, err := client.Vehicle(1234)
+		So(err, ShouldBeNil)
+		So(vehicle.DisplayName, ShouldEqual, "Macak")
+		So(vehicle.CalendarEnabled, ShouldBeTrue)
+	})
+
+	AuthURL = previousAuthURL
+	BaseURL = previousURL
 }

--- a/vehicles_test.go
+++ b/vehicles_test.go
@@ -14,9 +14,7 @@ func TestVehiclesSpec(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -26,6 +24,7 @@ func TestVehiclesSpec(t *testing.T) {
 		Password:     "go",
 	}
 	client, _ := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should get vehicles", t, func() {
 		vehicles, err := client.Vehicles()
@@ -35,5 +34,4 @@ func TestVehiclesSpec(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }

--- a/vehicles_test.go
+++ b/vehicles_test.go
@@ -64,31 +64,3 @@ func TestVehicle(t *testing.T) {
 	AuthURL = previousAuthURL
 	BaseURL = previousURL
 }
-
-func TestVehicle(t *testing.T) {
-	ts := serveHTTP(t)
-	defer ts.Close()
-	previousAuthURL := AuthURL
-	previousURL := BaseURL
-	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
-
-	auth := &Auth{
-		GrantType:    "password",
-		ClientID:     "abc123",
-		ClientSecret: "def456",
-		Email:        "elon@tesla.com",
-		Password:     "go",
-	}
-	client, _ := NewClient(auth)
-
-	Convey("Should get vehicle", t, func() {
-		vehicle, err := client.Vehicle(1234)
-		So(err, ShouldBeNil)
-		So(vehicle.DisplayName, ShouldEqual, "Macak")
-		So(vehicle.CalendarEnabled, ShouldBeTrue)
-	})
-
-	AuthURL = previousAuthURL
-	BaseURL = previousURL
-}

--- a/vehicles_test.go
+++ b/vehicles_test.go
@@ -41,9 +41,7 @@ func TestVehicle(t *testing.T) {
 	ts := serveHTTP(t)
 	defer ts.Close()
 	previousAuthURL := AuthURL
-	previousURL := BaseURL
 	AuthURL = ts.URL + "/oauth/token"
-	BaseURL = ts.URL + "/api/1"
 
 	auth := &Auth{
 		GrantType:    "password",
@@ -53,6 +51,7 @@ func TestVehicle(t *testing.T) {
 		Password:     "go",
 	}
 	client, _ := NewClient(auth)
+	client.BaseURL = ts.URL + "/api/1"
 
 	Convey("Should get vehicle", t, func() {
 		vehicle, err := client.Vehicle(1234)
@@ -62,5 +61,4 @@ func TestVehicle(t *testing.T) {
 	})
 
 	AuthURL = previousAuthURL
-	BaseURL = previousURL
 }


### PR DESCRIPTION
 `BaseURL` and `StreamingURL` seem like they should be part of `Client`.  They're still exported should someone want to change them inside the `Client`.

Also, by giving `Vehicle` a reference to the `Client` that created it `ActiveClient` doesn't need to exist.

I'm unclear if this change breaks any assumptions around the library, thus this pull request.

@andig in case you're aware of something this will break.