### PR TITLE
Create a new client creation API with functional options.

### DIFF
--- a/examples/manage_car.go
+++ b/examples/manage_car.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	ctx := context.Background()
 	email := "email@example.com"
-	client, err := tesla.New(ctx, tesla.WithTokenFile("/file/path/to/token.json"))
+	client, err := tesla.NewClient(ctx, tesla.WithTokenFile("/file/path/to/token.json"))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/manage_car.go
+++ b/examples/manage_car.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	ctx := context.Background()
 	email := "email@example.com"
-	client, err := tesla.NewClientFromTokenFile(ctx, "/file/path/to/token.json")
+	client, err := tesla.New(ctx, tesla.WithTokenFile("/file/path/to/token.json"))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/show_vehicle_info/main.go
+++ b/examples/show_vehicle_info/main.go
@@ -26,7 +26,7 @@ func main() {
 }
 
 func run(ctx context.Context, tokenPath string) error {
-	c, err := tesla.NewClientFromTokenFile(ctx, tokenPath)
+	c, err := tesla.New(ctx, tesla.WithTokenFile(tokenPath))
 	if err != nil {
 		return err
 	}

--- a/examples/show_vehicle_info/main.go
+++ b/examples/show_vehicle_info/main.go
@@ -26,7 +26,7 @@ func main() {
 }
 
 func run(ctx context.Context, tokenPath string) error {
-	c, err := tesla.New(ctx, tesla.WithTokenFile(tokenPath))
+	c, err := tesla.NewClient(ctx, tesla.WithTokenFile(tokenPath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Proposed v1.0 client.New interface. This will provide for future functional options to further configure the client. We should remove the other New* functions before tagging v1.0.