### PR TITLE
Expose login api

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-package main
+package tesla
 
 import (
 	"bytes"
@@ -20,7 +20,7 @@ const (
 	mfaVerifyURL = "https://auth.tesla.com/oauth2/v3/authorize/mfa/verify"
 )
 
-type device struct {
+type Device struct {
 	DispatchRequired bool      `json:"dispatchRequired"`
 	ID               string    `json:"id"`
 	Name             string    `json:"name"`
@@ -34,7 +34,7 @@ type device struct {
 type auth struct {
 	Client       *http.Client
 	AuthURL      string
-	SelectDevice func(ctx context.Context, devices []device) (d device, passcode string, err error)
+	SelectDevice func(ctx context.Context, devices []Device) (d Device, passcode string, err error)
 	userAgent    string
 }
 
@@ -158,7 +158,7 @@ func (a *auth) login(ctx context.Context, username, password string) (*http.Resp
 	return res, v, err
 }
 
-func (a *auth) listDevices(ctx context.Context, transactionID string) ([]device, error) {
+func (a *auth) listDevices(ctx context.Context, transactionID string) ([]Device, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, (&url.URL{
 		Scheme:   "https",
 		Host:     "auth.tesla.com",
@@ -181,7 +181,7 @@ func (a *auth) listDevices(ctx context.Context, transactionID string) ([]device,
 	}
 
 	var out struct {
-		Data []device `json:"data"`
+		Data []Device `json:"data"`
 	}
 	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
 		return nil, fmt.Errorf("json decode: %w", err)
@@ -189,7 +189,7 @@ func (a *auth) listDevices(ctx context.Context, transactionID string) ([]device,
 	return out.Data, nil
 }
 
-func (a *auth) verify(ctx context.Context, transactionID string, d device, passcode string) error {
+func (a *auth) verify(ctx context.Context, transactionID string, d Device, passcode string) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(map[string]string{
 		"transaction_id": transactionID,

--- a/auth.go
+++ b/auth.go
@@ -20,6 +20,7 @@ const (
 	mfaVerifyURL = "https://auth.tesla.com/oauth2/v3/authorize/mfa/verify"
 )
 
+// Device is the multi-factor device returned by the /authorize/mfa/factors endpoint
 type Device struct {
 	DispatchRequired bool      `json:"dispatchRequired"`
 	ID               string    `json:"id"`

--- a/auth_option.go
+++ b/auth_option.go
@@ -62,9 +62,11 @@ func (c *authHandler) login(ctx context.Context, oc *oauth2.Config) (*oauth2.Tok
 	return token, err
 }
 
-func defaultAuth() *auth {
-	return &auth{
-		SelectDevice: mfaUnsupported,
+func defaultHandler() *authHandler {
+	return &authHandler{
+		auth: &auth{
+			SelectDevice: mfaUnsupported,
+		},
 	}
 }
 
@@ -72,7 +74,7 @@ func defaultAuth() *auth {
 func WithMFAHandler(handler func(context.Context, []Device) (Device, string, error)) ClientOption {
 	return func(c *Client) error {
 		if c.authHandler == nil {
-			c.authHandler = &authHandler{auth: defaultAuth()}
+			c.authHandler = defaultHandler()
 		}
 
 		c.authHandler.auth.SelectDevice = handler
@@ -88,7 +90,7 @@ func mfaUnsupported(_ context.Context, _ []Device) (Device, string, error) {
 func WithCredentials(username, password string) ClientOption {
 	return func(c *Client) error {
 		if c.authHandler == nil {
-			c.authHandler = &authHandler{auth: defaultAuth()}
+			c.authHandler = defaultHandler()
 		}
 
 		c.authHandler.username = username

--- a/auth_option.go
+++ b/auth_option.go
@@ -43,7 +43,7 @@ func authHandler() *auth {
 func WithMFAHandler(handler func(context.Context, []Device) (Device, string, error)) ClientOption {
 	return func(c *Client) error {
 		if c.authHandler == nil {
-			c.authHandler = &auth{}
+			c.authHandler = authHandler()
 		}
 		c.authHandler.SelectDevice = handler
 		return nil
@@ -58,9 +58,7 @@ func mfaUnsupported(_ context.Context, _ []Device) (Device, string, error) {
 func WithCredentials(username, password string) ClientOption {
 	return func(c *Client) error {
 		if c.authHandler == nil {
-			c.authHandler = &auth{
-				SelectDevice: mfaUnsupported,
-			}
+			c.authHandler = authHandler()
 		}
 
 		verifier, challenge, err := pkce()

--- a/auth_option.go
+++ b/auth_option.go
@@ -1,0 +1,92 @@
+package tesla
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/oauth2"
+)
+
+// github.com/uhthomas/tesla
+func state() string {
+	var b [9]byte
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:])
+}
+
+// https://www.oauth.com/oauth2-servers/pkce/
+func pkce() (verifier, challenge string, err error) {
+	var p [87]byte
+	if _, err := io.ReadFull(rand.Reader, p[:]); err != nil {
+		return "", "", fmt.Errorf("rand read full: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(p[:])
+	b := sha256.Sum256([]byte(challenge))
+	challenge = base64.RawURLEncoding.EncodeToString(b[:])
+	return verifier, challenge, nil
+}
+
+func authHandler() *auth {
+	return &auth{
+		SelectDevice: mfaUnsupported,
+	}
+}
+
+// WithMFAHandler allows a consumer to provide a different configuration from the default.
+func WithMFAHandler(handler func(context.Context, []Device) (Device, string, error)) ClientOption {
+	return func(c *Client) error {
+		if c.authHandler == nil {
+			c.authHandler = &auth{}
+		}
+		c.authHandler.SelectDevice = handler
+		return nil
+	}
+}
+
+func mfaUnsupported(_ context.Context, _ []Device) (Device, string, error) {
+	return Device{}, "", errors.New("multi factor authentication is not supported")
+}
+
+// WithCredentials allows a consumer to provide a different configuration from the default.
+func WithCredentials(username, password string) ClientOption {
+	return func(c *Client) error {
+		if c.authHandler == nil {
+			c.authHandler = &auth{
+				SelectDevice: mfaUnsupported,
+			}
+		}
+
+		verifier, challenge, err := pkce()
+		if err != nil {
+			return err
+		}
+
+		c.authHandler.AuthURL = c.oc.AuthCodeURL(state(), oauth2.AccessTypeOffline,
+			oauth2.SetAuthURLParam("code_challenge", challenge),
+			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		)
+
+		ctx := context.Background()
+		code, err := c.authHandler.Do(ctx, username, password)
+		if err != nil {
+			return err
+		}
+
+		token, err := c.oc.Exchange(ctx, code,
+			oauth2.SetAuthURLParam("code_verifier", verifier),
+		)
+
+		if err == nil {
+			c.token = token
+		}
+
+		return err
+	}
+}

--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	hc           *http.Client
 	oc           *oauth2.Config
 	token        *oauth2.Token
+	authHandler  *auth
 }
 
 // New creates a new Tesla API client. You must provided one of WithToken or WithTokenFile
@@ -54,6 +55,10 @@ func NewClient(ctx context.Context, options ...ClientOption) (*Client, error) {
 	client.hc = client.oc.Client(ctx, client.token)
 
 	return client, nil
+}
+
+func (c Client) Token() *oauth2.Token {
+	return c.token
 }
 
 // Calls an HTTP GET

--- a/client.go
+++ b/client.go
@@ -56,7 +56,6 @@ func NewClient(ctx context.Context, options ...ClientOption) (*Client, error) {
 
 		var err error
 		client.token, err = client.authHandler.login(ctx, client.oc)
-
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix #22.

This is still too convoluted but it should give an idea how it could look:
- `WithMFAHandler` will set the device handler for MFA, if omitted MFA is not supported
- the `WithCredentials` option will trigger the login and must be the last option

I'm using it like this:

	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, request.NewHelper(log).Client)
	client, err := tesla.NewClient(
		ctx,
		tesla.WithMFAHandler(codePrompt),
		tesla.WithCredentials(username, password),
	)
	if err != nil {
		log.FATAL.Fatalln(err)
	}

	token := client.Token()

Comments welcome.

/cc @uhthomas 