### PR TITLE
Include the client when creating a new Vehicle struct.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -113,6 +113,7 @@ func (v Vehicle) Wakeup() (*Vehicle, error) {
 	if err := json.Unmarshal(body, vehicleResponse); err != nil {
 		return nil, err
 	}
+	vehicleResponse.Response.c = v.c
 	return vehicleResponse.Response, nil
 }
 


### PR DESCRIPTION
This fixes a crash when the returned vehicle struct is used with additional access requests.