### PR TITLE
Support for reading and writing Powerwall 'Energy Exports' and 'Grid Charging'

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,11 @@ type CommandResponse struct {
 	} `json:"response"`
 }
 
+// Some API end-points just respond with {"response":""}
+type CommandEmptyResponse struct {
+	Response string `json:"response"`
+}
+
 // AutoParkRequest are the required elements to POST an Autopark/Summon request for the vehicle.
 type AutoParkRequest struct {
 	VehicleID uint64  `json:"vehicle_id,omitempty"`

--- a/energysite.go
+++ b/energysite.go
@@ -154,7 +154,7 @@ func (s *EnergySite) SetGridCharging(enabled bool) error {
 	url := s.basePath() + "/grid_import_export"
 	payload := fmt.Sprintf(`{"disallow_charge_from_grid_with_solar_installed":%t}`, !enabled)
 
-	if _, err := s.sendCommandExpectingEmptyResponse(url, []byte(payload)); err != nil {
+	if err := s.sendCommandExpectingEmptyResponse(url, []byte(payload)); err != nil {
 		return err
 	}
 
@@ -169,7 +169,7 @@ func (s *EnergySite) SetExportRule(exportRule CustomerPreferredExportRule) error
 	url := s.basePath() + "/grid_import_export"
 	payload := fmt.Sprintf(`{"customer_preferred_export_rule": "%s"}`, exportRule)
 
-	if _, err := s.sendCommandExpectingEmptyResponse(url, []byte(payload)); err != nil {
+	if err := s.sendCommandExpectingEmptyResponse(url, []byte(payload)); err != nil {
 		return err
 	}
 
@@ -214,19 +214,19 @@ func (s *EnergySite) sendCommand(url string, reqBody []byte) ([]byte, error) {
 	return body, nil
 }
 
-func (s *EnergySite) sendCommandExpectingEmptyResponse(url string, reqBody []byte) ([]byte, error) {
+func (s *EnergySite) sendCommandExpectingEmptyResponse(url string, reqBody []byte) error {
 	body, err := s.c.post(url, reqBody)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(body) > 0 {
 		response := &CommandEmptyResponse{}
 		if err := json.Unmarshal(body, response); err != nil {
-			return nil, err
+			return err
 		}
 		if response.Response != "" {
-			return nil, errors.New(fmt.Sprintf("Unexpected response: %s", body))
+			return errors.New(fmt.Sprintf("Unexpected response: %s", body))
 		}
 	}
-	return body, nil
+	return nil
 }


### PR DESCRIPTION
The following two options may exist in the Tesla app, for Powerwall, if those features are enabled for your Powerwall:

![image](https://github.com/bogosj/tesla/assets/330908/dc93ec3e-9205-4974-ab83-68be6cd05212)

This PR provides the capability to read and write those values:

```go
energySite, err := client.EnergySite(product.EnergySiteId)

// Read the values
gridChargingEnabled := !energySite.Components.DisallowChargeFromGridWithSolarInstalled
energyExports := energySite.Components.CustomerPreferredExportRule

// Write them
err = energySite.SetGridCharging(false)
err = energySite.SetExportRule(tesla.PvOnly)
err = energySite.SetExportRule(tesla.BatteryOk)
```

Happy to make any changes you want, if this PR isn't consistent with the rest of your library. Just let me know what needs changing, or feel free to change yourself.